### PR TITLE
Added show only at critical

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -36,6 +36,10 @@
 			"runForNpc": {
 				"name": "Run for NPC",
 				"hint": "Runt the timer on NPCs turn"
+			},
+			"showOnlyAtCritical": {
+				"name": "Show only at critical",
+				"hint": "Timer is hidden until the critical time is hit"
 			}
         }
     }

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -108,6 +108,15 @@ Hooks.once("init", async function () {
     type: Boolean,
     default: false,
   });
+  
+  game.settings.register("hurry-up", "showOnlyAtCritical", {
+    name: game.i18n.localize("hp.settings.showOnlyAtCritical.name"),
+    hint: game.i18n.localize("hp.settings.showOnlyAtCritical.hint"),
+    scope: "word",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
 
 
 });

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -22,6 +22,11 @@ class CombatTimer extends Application {
   async startTimer() {
     this.reset();
     await this.sleep(1000)
+	const showOnlyAtCritical = game.settings.get("hurry-up", "showOnlyAtCritical");
+	if(showOnlyAtCritical)
+	{
+		$("#combat-timer").hide(1000);
+	}
     this.currentTime = this.time;
     this.started = true;
     while (this.started && this.currentTime > 0) {
@@ -58,6 +63,12 @@ class CombatTimer extends Application {
   }
 
   async onCritical(){
+	const showOnlyAtCritical = game.settings.get("hurry-up", "showOnlyAtCritical");
+	if(showOnlyAtCritical)
+	{
+		$("#combat-timer").show();
+	}
+	
     this.critSound?.stop();
     const soundP = game.settings.get("hurry-up", "critSoundPath")
     if(soundP) this.critSound = await AudioHelper.play({src: soundP, autoplay:true , volume: game.settings.get("hurry-up", "soundVol"), loop: true}, false);


### PR DESCRIPTION
Added show only at critical setting. It hides the counter until the critical time is hit. By default it is disabled (so by the default the counter is visible all the time, as now).

Some of my players were complaining that this is distracting them too much, this is a solution when if this setting is checked they will not see the counter unless their turn time is getting low.