### PR TITLE
Added seconds instead of percentage setting

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -36,6 +36,10 @@
 			"runForNpc": {
 				"name": "Run for NPC",
 				"hint": "Runt the timer on NPCs turn"
+			},
+			"secondsInsteadOfPercentage": {
+				"name": "Critical time use seconds instead of percentage",
+				"hint": "By default the critical threshold uses percentage of total time. By checking this setting it's changed to seconds instead."
 			}
         }
     }

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -57,6 +57,14 @@ Hooks.once("init", async function () {
     default: 10,
   });
 
+  game.settings.register("hurry-up", "secondsInsteadOfPercentage", {
+    name: game.i18n.localize("hp.settings.secondsInsteadOfPercentage.name"),
+    hint: game.i18n.localize("hp.settings.secondsInsteadOfPercentage.hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
   game.settings.register("hurry-up", "goNext", {
     name: game.i18n.localize("hp.settings.goNext.name"),
     hint: game.i18n.localize("hp.settings.goNext.hint"),

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -86,17 +86,32 @@ class CombatTimer extends Application {
   }
 
   checkCritical(){
-    const percent = (this.currentTime / this.time) * 100;
-    if (percent <= game.settings.get("hurry-up", "critical")) {
+   let isCurrentCritical = false;
+   const secondsInsteadOfPercentage = game.settings.get("hurry-up", "secondsInsteadOfPercentage");
+   if(secondsInsteadOfPercentage)
+   {
+      if(this.currentTime <= game.settings.get("hurry-up", "critical"))
+      {
+         isCurrentCritical = true;
+      }
+   }else{
+      const percent = (this.currentTime / this.time) * 100;
+      if (percent <= game.settings.get("hurry-up", "critical")) {
+        isCurrentCritical = true;
+      }
+   }
+   
+   if(isCurrentCritical)
+   {
       if(!this.isCritical){
-        this.isCritical = true;
-        this.onCritical();
+         this.isCritical = true;
+         this.onCritical();
       }
       $(this.element)
         .find(".combat-timer-bar")
         .css("background-color", "rgba(255, 0, 0, 0.26)");
       $(this.element).find(".combat-timer-timer-text").addClass("blinking");
-    }
+   }
   }
 
   activateListeners(html) {


### PR DESCRIPTION
Using last percentage seconds instead of just last seconds can be a bit confusing if user wants to have a set time of critical threshhold instead of percentage of the overall time..

For example: an user wants to always blink for last 10 seconds and have 100 seconds overall timer. They set the critical threshhold to 10 and it works as intended. However later they change the overall timer to 60 seconds, to have 10 seconds as the critical threshold they need to change the setting from 10 to 17 which may not be very obvious and confuse them if they want to just have 10 seconds no matter the overall timer. Checking the new box solves the issue. Leaving it as unchecked does not change any behaviour