### PR TITLE
showOnUpdateCombatOnly, sleepTimeout, spelling

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -2,7 +2,7 @@
     "hp":{
         "settings":{
             "timerDuration":{
-                "name": "Timer duration",
+                "name": "Timer Duration",
                 "hint": "Duration in seconds of the timer"
             },
             "size":{
@@ -10,7 +10,7 @@
                 "hint": "Size of the timer"
             },
             "critical":{
-                "name": "Critical Treshold",
+                "name": "Critical Threshold",
                 "hint": "Threshold after which the timer will go critical and start blinking"
             },
             "goNext": {
@@ -35,8 +35,12 @@
             },
 			"runForNpc": {
 				"name": "Run for NPC",
-				"hint": "Runt the timer on NPCs turn"
-			}
+				"hint": "Run the timer on NPCs turn"
+			},
+            "showOnUpdateCombatOnly": {
+                "name": "First Show Timer on Next Turn",
+				"hint": "First show the combat timer when 'Begin Combat', 'Next Turn' or 'End Turn' is pressed"
+            }
         }
     }
 }

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -108,6 +108,14 @@ Hooks.once("init", async function () {
     type: Boolean,
     default: false,
   });
-
+  
+  game.settings.register("hurry-up", "showOnUpdateCombatOnly", {
+    name: game.i18n.localize("hp.settings.showOnUpdateCombatOnly.name"),
+    hint: game.i18n.localize("hp.settings.showOnUpdateCombatOnly.hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
 
 });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,5 +1,5 @@
 Hooks.on("canvasReady", () => {
-  if (!game.combat?.started) return;
+  if (!game.combat?.started || game.settings.get("hurry-up", "showOnUpdateCombatOnly")) return;
   const token = canvas.tokens.get(game?.combat?.current?.tokenId);
   const actor = token?.actor;
   if (actor?.hasPlayerOwner && !game.settings.get("hurry-up", "disable")) {
@@ -12,7 +12,7 @@ Hooks.on("updateCombat", (combat, updates) => {
     game.combatTimer?.close(true);
     return;
   }
-  if ("turn" in updates && !game.settings.get("hurry-up", "disable")) {
+  if (("turn" in updates || "round" in updates) && !game.settings.get("hurry-up", "disable")) {
     const token = canvas.tokens.get(game?.combat?.current?.tokenId);
     const actor = token?.actor;
     if (game.settings.get("hurry-up", "runForNPC") || actor?.hasPlayerOwner) {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -4,6 +4,7 @@ class CombatTimer extends Application {
     this.time = time;
     this.started = false;
     this.selfDestruct = selfDestruct;
+    this.sleepTimeout = undefined;
   }
 
   static get defaultOptions() {
@@ -20,8 +21,8 @@ class CombatTimer extends Application {
   }
 
   async startTimer() {
+    
     this.reset();
-    await this.sleep(1000)
     this.currentTime = this.time;
     this.started = true;
     while (this.started && this.currentTime > 0) {
@@ -36,6 +37,7 @@ class CombatTimer extends Application {
   }
 
   reset(){
+    clearTimeout(this.sleepTimeout);
     this.started = false;
     this.isCritical = false;
     $(this.element)
@@ -68,7 +70,7 @@ class CombatTimer extends Application {
   }
 
   async sleep(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return new Promise((resolve) => this.sleepTimeout = setTimeout(resolve, ms));
   }
 
   updateTime() {


### PR DESCRIPTION
- showOnUpdateCombatOnly: Add setting to only show timer when combat
  updates. Avoids players running on different timers when combat has
  started and players reload FoundryVTT.
- sleepTimeout: Clear timeout to stop concurrent loops when
   startTimer is triggered multiple times before existing loop restarts.
- spelling: Minor spelling fixes.