### PR TITLE
Time on start, Update on close, Core version

### DIFF
--- a/module.json
+++ b/module.json
@@ -36,7 +36,7 @@
   "packs": [
   ],
   "minimumCoreVersion": "0.8.6",
-  "compatibleCoreVersion": "0.8.9",
+  "compatibleCoreVersion": "9",
   "url": "https://github.com/theripper93/hurry-up",
   "manifest": "https://github.com/theripper93/hurry-up/releases/latest/download/module.json",
   "download": "https://github.com/theripper93/hurry-up/releases/latest/download/module.zip",

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -34,7 +34,7 @@ class CombatTimer extends Application {
   async startTimer() {
     this.reset();
     this.started = true;
-    this.timeRemaining = this.time * 1000;
+    this.timeRemaining = this.time;
     if (game?.paused) {
       this.timeStarted = this.timePaused;
     } else {
@@ -380,6 +380,7 @@ class CombatTimer extends Application {
   }
 
   close() {
+    clearInterval(this.sleepTimer);
     this.started = false;
     this.critSound?.stop();
     super.close();
@@ -389,7 +390,7 @@ class CombatTimer extends Application {
     let template;
     switch(game.settings.get("hurry-up", "style")) {
       case "digits":
-       template = `modules/hurry-up/templates/hurry-up-digits.hbs`
+        template = `modules/hurry-up/templates/hurry-up-digits.hbs`
         break;
       case "circle":
       case "sand":


### PR DESCRIPTION
- Time on start: Remove timeRemaining multiplier to fix incorrect
  time displaying while the timer is started and the game is paused.
- Update on close: Clear interval to stop the updateTime loop
  continuing when the timer is closed.
- Core version: Set compatibleCoreVersion to 9.