### PR TITLE
Count up and Overtime options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Tired of those pesky players taking forever to then just swing a longsword after
 - **Critical**: Chose the duration of the timer and when it goes critical, at this point the progress bar will turn red and start blinking
 - **Sounds**: Play a looping sound when the timer goes critical (defaults to ticking) and a sound when the time is over
 - **Go Next**: Automatically advance the turn tracker when a timer ends
+- **Count Up**: Timer counts up like a stopwatch to show turn duration
+- **Overtime**: Open-ended timer without hard stop to softly shame slow players (visible in digit mode only)

--- a/languages/en.json
+++ b/languages/en.json
@@ -13,6 +13,14 @@
                 "name": "Style",
                 "hint": "Style of the timer"
             },
+            "countup":{
+                "name": "Counting Up",
+                "hint": "Timer counts up instead of down (Digits and Circle styles only)"
+            },
+            "overtime":{
+                "name": "Overtime",
+                "hint": "Timer keeps running after maximum time allowance"
+            },
             "size":{
                 "name": "Size",
                 "hint": "Size of the timer"
@@ -31,7 +39,7 @@
 			},
             "goNext": {
                 "name": "Go Next",
-                "hint": "Go to next combatant when timer ends"
+                "hint": "Go to next combatant when timer ends. Does not trigger when overtime is allowed."
             },
 			"runForNpc": {
 				"name": "Run for NPC",

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -40,6 +40,24 @@ Hooks.once("init", async function () {
     }
   });
 
+  game.settings.register("hurry-up", "countup", {
+    name: game.i18n.localize("hp.settings.countup.name"),
+    hint: game.i18n.localize("hp.settings.countup.hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+
+  game.settings.register("hurry-up", "overtime", {
+    name: game.i18n.localize("hp.settings.overtime.name"),
+    hint: game.i18n.localize("hp.settings.overtime.hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+
   game.settings.register("hurry-up", "size", {
     name: game.i18n.localize("hp.settings.size.name"),
     hint: game.i18n.localize("hp.settings.size.hint"),

--- a/styles/module.css
+++ b/styles/module.css
@@ -58,7 +58,7 @@
   z-index: 10;
   height: 100%;
   background: var(--hurry-up-bar-color);
-  transition: width 0.5s ease-in-out;
+  transition: width 0.4s ease-out;
 }
 
 #hurry-up .blinking {


### PR DESCRIPTION
This adds two new settings, Countup and Overtime.

Counting up just reverses the display, digits count up, circle fills up, sand is unaffected.

Overtime does not end the timer on exceeding the timer. The end sound is still played.  In combination with counting up, the clock keeps ticking, showing the turn duration.

This is informative to show how far the turn duration has been exceeded.

https://user-images.githubusercontent.com/673417/213742540-0e0ef5db-6fda-4108-8119-0b76276ff9ea.mp4

