### PR TITLE
Add settings to change start position of timer.

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -29,6 +29,14 @@
                 "name": "Windowless",
                 "hint": "Display the timer without a window"
             },
+	    "posTop":{
+                "name": "Vertical Position",
+                "hint": "Position of the window from the top. Default: 2"
+            },
+	    "posLeft":{
+                "name": "Horizontal Position",
+                "hint": "Position of the window from the right. Default 310"
+            },
             "critical":{
                 "name": "Critical Threshold",
                 "hint": "Threshold after which the timer will go critical and start blinking"

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -78,6 +78,13 @@ Hooks.once("init", async function () {
     }
   });
 
+  game.settings.register("hurry-up", "position", {
+        scope: 'client',
+        config: false,
+        type: Object,
+        requiresReload: false,
+  });
+
   game.settings.register("hurry-up", "windowless", {
     name: game.i18n.localize("hp.settings.windowless.name"),
     hint: game.i18n.localize("hp.settings.windowless.hint"),

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -78,11 +78,38 @@ Hooks.once("init", async function () {
     }
   });
 
-  game.settings.register("hurry-up", "position", {
+  game.settings.register("hurry-up", "posTop", {
+        name: game.i18n.localize("hp.settings.posTop.name"),
+        hint: game.i18n.localize("hp.settings.posTop.hint"),
         scope: 'client',
-        config: false,
-        type: Object,
+        config: True,
+        type: Number,
+        default: 2,
+        range: {
+            min:0,
+            max:window.innerHeight,
+        },
         requiresReload: false,
+        onChange: () => {
+          game.combatTimer.position.top;
+        }
+  });
+
+  game.settings.register("hurry-up", "posLeft", {
+        name: game.i18n.localize("hp.settings.posLeft.name"),
+        hint: game.i18n.localize("hp.settings.posLeft.hint"),
+        scope: 'client',
+        config: True,
+        type: Number,
+        default: 310,
+        range: {
+            min:0,
+            max:window.innerWidth,
+        },
+        requiresReload: false,
+        onChange: () => {
+          game.combatTimer.position.left;
+        }
   });
 
   game.settings.register("hurry-up", "windowless", {

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -82,13 +82,9 @@ Hooks.once("init", async function () {
         name: game.i18n.localize("hp.settings.posTop.name"),
         hint: game.i18n.localize("hp.settings.posTop.hint"),
         scope: 'client',
-        config: True,
-        type: Number,
+        config: true,
+        type: String,
         default: 2,
-        range: {
-            min:0,
-            max:window.innerHeight,
-        },
         requiresReload: false,
         onChange: () => {
           game.combatTimer.position.top;
@@ -99,14 +95,10 @@ Hooks.once("init", async function () {
         name: game.i18n.localize("hp.settings.posLeft.name"),
         hint: game.i18n.localize("hp.settings.posLeft.hint"),
         scope: 'client',
-        config: True,
-        type: Number,
+        config: true,
+        type: String,
         default: 310,
-        range: {
-            min:0,
-            max:window.innerWidth,
-        },
-        requiresReload: false,
+        requiresReload: true,
         onChange: () => {
           game.combatTimer.position.left;
         }
@@ -118,7 +110,7 @@ Hooks.once("init", async function () {
     scope: "client",
     config: true,
     type: Boolean,
-    default: false,
+    default: true,
     onChange: () => {
       if(game.combatTimer) game.combatTimer.updateWindowless();
     }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -382,12 +382,13 @@ class CombatTimer extends Application {
     html.find(".header-button").remove();
     if (!this.positioned){
       this.positioned = true;
-      const top = 2
-      const left = window.innerWidth - this.element.width() - 310;
+      const top = game.settings.get("hurry-up", "posTop") ?? 2
+      const left = game.settings.get("hurry-up", "posLeft") ?? window.innerWidth - this.element.width() - 310;
       this.element.css({"top": top, "left": left});
       this.position.top = top;
       this.position.left = left;
     }
+    
     switch (game.settings.get("hurry-up", "style")) {
       case "digits":
           this.updateDigits();

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -383,7 +383,7 @@ class CombatTimer extends Application {
     if (!this.positioned){
       this.positioned = true;
       const top = game.settings.get("hurry-up", "posTop") ?? 2
-      const left = game.settings.get("hurry-up", "posLeft") ?? window.innerWidth - this.element.width() - 310;
+      const left = (window.innerWidth - this.element.width() - game.settings.get("hurry-up", "posLeft")) ?? (window.innerWidth - this.element.width() - 310);
       this.element.css({"top": top, "left": left});
       this.position.top = top;
       this.position.left = left;


### PR DESCRIPTION
I've seen this requested a few times now, and admittedly it would be better for it to remember its position rather than set it manually, but it wasn't obvious to me how/where the position was stored after it was moved.

This will resolve issues with PF2e and DFreds Effects Panel, both of which add status effects (among other things) directly to the left of the right hand menu. Currently this timer sits on top of those icons. Another solution would be to set the default horizontal position over 20-30 pixels, but this feels like a better solution so people can choose.

Currently requires a refresh to change settings, but accessing the right variable might resolve that so that it's dynamic. From what I could tell position was only set on startup, and then just relied on the draggable element afterwards.